### PR TITLE
Don't parse JSON inside iframes. Fixes #7.

### DIFF
--- a/JSON Formatter.safariextension/Info.plist
+++ b/JSON Formatter.safariextension/Info.plist
@@ -1,51 +1,53 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>Author</key>
-    <string>Rick Fletcher</string>
-    <key>CFBundleDisplayName</key>
-    <string>JSON Formatter</string>
-    <key>CFBundleIdentifier</key>
-    <string>ch.flet.safari.jsonformatter</string>
-    <key>CFBundleInfoDictionaryVersion</key>
-    <string>6.0</string>
-    <key>CFBundleShortVersionString</key>
-    <string>1.0.1</string>
-    <key>CFBundleVersion</key>
-    <string>2</string>
-    <key>Chrome</key>
-    <dict>
-      <key>Global Page</key>
-      <string>proxy.html</string>
-    </dict>
-    <key>Content</key>
-    <dict>
-      <key>Scripts</key>
-      <dict>
-        <key>End</key>
-        <array>
-          <string>formattedJSON.js</string>
-        </array>
-      </dict>
-    </dict>
-    <key>Description</key>
-    <string>Formats JSON responses so they can be read by a human</string>
-    <key>ExtensionInfoDictionaryVersion</key>
-    <string>1.0</string>
-    <key>Permissions</key>
-    <dict>
-      <key>Website Access</key>
-      <dict>
-        <key>Include Secure Pages</key>
-        <true/>
-        <key>Level</key>
-        <string>All</string>
-      </dict>
-    </dict>
-    <key>Update Manifest URL</key>
-    <string>http://github.com/rfletcher/safari-json-formatter/raw/latest/Update.plist</string>
-    <key>Website</key>
-    <string>http://github.com/rfletcher/safari-json-formatter</string>
-  </dict>
+<dict>
+	<key>Author</key>
+	<string>Rick Fletcher</string>
+	<key>Builder Version</key>
+	<string>7534.48.3</string>
+	<key>CFBundleDisplayName</key>
+	<string>JSON Formatter</string>
+	<key>CFBundleIdentifier</key>
+	<string>ch.flet.safari.jsonformatter</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0.2</string>
+	<key>CFBundleVersion</key>
+	<string>3</string>
+	<key>Chrome</key>
+	<dict>
+		<key>Global Page</key>
+		<string>proxy.html</string>
+	</dict>
+	<key>Content</key>
+	<dict>
+		<key>Scripts</key>
+		<dict>
+			<key>End</key>
+			<array>
+				<string>formattedJSON.js</string>
+			</array>
+		</dict>
+	</dict>
+	<key>Description</key>
+	<string>Formats JSON responses so they can be read by a human</string>
+	<key>ExtensionInfoDictionaryVersion</key>
+	<string>1.0</string>
+	<key>Permissions</key>
+	<dict>
+		<key>Website Access</key>
+		<dict>
+			<key>Include Secure Pages</key>
+			<true/>
+			<key>Level</key>
+			<string>All</string>
+		</dict>
+	</dict>
+	<key>Update Manifest URL</key>
+	<string>http://github.com/rfletcher/safari-json-formatter/raw/latest/Update.plist</string>
+	<key>Website</key>
+	<string>http://github.com/rfletcher/safari-json-formatter</string>
+</dict>
 </plist>

--- a/JSON Formatter.safariextension/formattedJSON.js
+++ b/JSON Formatter.safariextension/formattedJSON.js
@@ -5,6 +5,9 @@
      *  TODO: examine the document's content-type (appears to be impossible)
      */
     init: function() {
+      if (window != window.top) {
+        return;
+      }
       // attempt to parse the body as JSON
       try {
         var obj = JSON.parse( document.body.textContent


### PR DESCRIPTION
The only non-whitespace changes in Info.plist are to change the version number. The whitespace changes came from the Safari Extension Builder, so I figured I'd leave them.
